### PR TITLE
Supported multi-argument signal (`Observable.from_signal`)

### DIFF
--- a/addons/signal_extensions/factories/from_signal.gd
+++ b/addons/signal_extensions/factories/from_signal.gd
@@ -39,7 +39,7 @@ func _init(sig: Signal) -> void:
 		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant, value4: Variant, value5: Variant, value6: Variant, value7: Variant, value8: Variant) -> void: _on_next.emit([value1, value2, value3, value4, value5, value6, value7, value8]))
 	else:
 		set_block_signals(true)
-		assert(false, "Signal has too many arguments. Max 8 arguments are supported.")
+		assert(false, "Signal '%s' has %d arguments, which exceeds the maximum of 8 supported arguments." % [sig.get_name(), sig_arg_count])
 
 
 func _subscribe_core(observer: Callable) -> Disposable:

--- a/addons/signal_extensions/factories/from_signal.gd
+++ b/addons/signal_extensions/factories/from_signal.gd
@@ -10,23 +10,37 @@ func _init(sig: Signal) -> void:
 		set_block_signals(true)
 		return
 
-        # Check signal's argument count
-        var signal_info := sig.get_object().get_signal_list().filter(func(info: Dictionary) -> bool:
-                return info.name == sig.get_name()
-        )
-        assert(signal_info.size() == 1)
+	# Check signal's argument count
+	var signal_info := sig.get_object().get_signal_list().filter(func(info: Dictionary) -> bool:
+		return info.name == sig.get_name()
+	)
+	assert(signal_info.size() == 1)
 
-        _source_signal = sig
+	var sig_arg_count: int = signal_info[0]["args"].size()
+	_source_signal = sig
 
-        _source_signal.connect(func(... args) -> void:
-                match args.size():
-                        0:
-                                _on_next.emit(Unit.default)
-                        1:
-                                _on_next.emit(args[0])
-                        _:
-                                _on_next.emit(args)
-        )
+	if sig_arg_count == 0:
+		_source_signal.connect(func() -> void: _on_next.emit(Unit.default))
+	elif sig_arg_count == 1:
+		_source_signal.connect(func(value: Variant) -> void: _on_next.emit(value))
+	elif sig_arg_count == 2:
+		_source_signal.connect(func(value1: Variant, value2: Variant) -> void: _on_next.emit([value1, value2]))
+	elif sig_arg_count == 3:
+		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant) -> void: _on_next.emit([value1, value2, value3]))
+	elif sig_arg_count == 4:
+		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant, value4: Variant) -> void: _on_next.emit([value1, value2, value3, value4]))
+	elif sig_arg_count == 5:
+		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant, value4: Variant, value5: Variant) -> void: _on_next.emit([value1, value2, value3, value4, value5]))
+	elif sig_arg_count == 6:
+		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant, value4: Variant, value5: Variant, value6: Variant) -> void: _on_next.emit([value1, value2, value3, value4, value5, value6]))
+	elif sig_arg_count == 7:
+		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant, value4: Variant, value5: Variant, value6: Variant, value7: Variant) -> void: _on_next.emit([value1, value2, value3, value4, value5, value6, value7]))
+	elif sig_arg_count == 8:
+		_source_signal.connect(func(value1: Variant, value2: Variant, value3: Variant, value4: Variant, value5: Variant, value6: Variant, value7: Variant, value8: Variant) -> void: _on_next.emit([value1, value2, value3, value4, value5, value6, value7, value8]))
+	else:
+		set_block_signals(true)
+		assert(false, "Signal has too many arguments. Max 8 arguments are supported.")
+
 
 func _subscribe_core(observer: Callable) -> Disposable:
 	if not _source_signal:

--- a/test/factories/from_signal_test.gd
+++ b/test/factories/from_signal_test.gd
@@ -32,25 +32,26 @@ func test_from_signal_oneparm() -> void:
 	assert_int(_result_int).is_equal(2)
 
 func test_from_signal_twoparms() -> void:
-        var result: Array = []
-        var d1 := Observable.from_signal(twoparms).subscribe(func(arr: Array) -> void:
-                result = arr
-        )
-        twoparms.emit(1.0, "ok")
-        assert_array(result).is_equal([1.0, "ok"])
+	var result: Array = []
+	var d1 := Observable.from_signal(twoparms).subscribe(func(arr: Array) -> void:
+			result.append_array(arr)
+	)
+	twoparms.emit(1.0, "ok")
+	assert_array(result).is_equal([1.0, "ok"])
 
-        d1.dispose()
-        twoparms.emit(2.0, "ng")
-        assert_array(result).is_equal([1.0, "ok"])
+	d1.dispose()
+	twoparms.emit(2.0, "ng")
+	assert_array(result).is_equal([1.0, "ok"])
+
 
 func test_from_signal_threeparms() -> void:
-        var result: Array = []
-        var d1 := Observable.from_signal(threeparms).subscribe(func(arr: Array) -> void:
-                result = arr
-        )
-        threeparms.emit(1, 2, 3)
-        assert_array(result).is_equal([1, 2, 3])
+	var result: Array = []
+	var d1 := Observable.from_signal(threeparms).subscribe(func(arr: Array) -> void:
+			result.append_array(arr)
+	)
+	threeparms.emit(1, 2, 3)
+	assert_array(result).is_equal([1, 2, 3])
 
-        d1.dispose()
-        threeparms.emit(4, 5, 6)
-        assert_array(result).is_equal([1, 2, 3])
+	d1.dispose()
+	threeparms.emit(4, 5, 6)
+	assert_array(result).is_equal([1, 2, 3])

--- a/test/factories/from_signal_test.gd
+++ b/test/factories/from_signal_test.gd
@@ -4,6 +4,7 @@ var _result_int: int
 signal noparms
 signal oneparm(x: float)
 signal twoparms(x: float, y: String)
+signal threeparms(a: int, b: int, c: int)
 
 func test_from_signal_noparm() -> void:
 	_result_int = 0
@@ -31,6 +32,25 @@ func test_from_signal_oneparm() -> void:
 	assert_int(_result_int).is_equal(2)
 
 func test_from_signal_twoparms() -> void:
-	@warning_ignore("untyped_declaration")
-	await assert_error(func(): Observable.from_signal(twoparms).subscribe(func(_x): pass )) \
-		.is_push_error("signal should have 0 or 1 argument. twoparms has 2 arguments")
+        var result: Array = []
+        var d1 := Observable.from_signal(twoparms).subscribe(func(arr: Array) -> void:
+                result = arr
+        )
+        twoparms.emit(1.0, "ok")
+        assert_array(result).is_equal([1.0, "ok"])
+
+        d1.dispose()
+        twoparms.emit(2.0, "ng")
+        assert_array(result).is_equal([1.0, "ok"])
+
+func test_from_signal_threeparms() -> void:
+        var result: Array = []
+        var d1 := Observable.from_signal(threeparms).subscribe(func(arr: Array) -> void:
+                result = arr
+        )
+        threeparms.emit(1, 2, 3)
+        assert_array(result).is_equal([1, 2, 3])
+
+        d1.dispose()
+        threeparms.emit(4, 5, 6)
+        assert_array(result).is_equal([1, 2, 3])


### PR DESCRIPTION
## Summary
- allow `from_signal` to accept signals with any argument count
- emit array values when the signal provides multiple arguments
- update tests for two and three parameter signals

## Testing
- `godot --version` *(fails: command not found)*