### PR TITLE
Refactor ReactiveProperty: Replace check_equality with _should_update()

### DIFF
--- a/addons/signal_extensions/reactive_property.gd
+++ b/addons/signal_extensions/reactive_property.gd
@@ -20,9 +20,6 @@ const Subscription = preload("subscription.gd")
 ## @deprecated: This is an internal implementation detail and should not be used directly.
 signal _on_next(value: Variant)
 
-## Whether to check for equality before emitting changes.
-var _check_equality: bool
-
 ## The current value of the reactive property.
 ##
 ## Setting this property will trigger notifications to all subscribers
@@ -41,19 +38,24 @@ var value: Variant:
 ## Creates a new ReactiveProperty with an initial value.
 ##
 ## The reactive property will store the initial value and emit it to new subscribers.
-## Optionally, you can disable equality checking to force emission on every value assignment.
+## By default, the property only emits changes when the new value differs from the current value.
+## You can customize this behavior by overriding [method _should_update].
 ##
 ## Usage:
 ## [codeblock]
-## var health := ReactiveProperty.new(100)      # With equality check
-## var score := ReactiveProperty.new(0, false)  # Without equality check
+## var health := ReactiveProperty.new(100)
+##
+## # Custom validation example
+## class ValidatedHP extends ReactiveProperty:
+##     func _should_update(old_value, new_value) -> bool:
+##         if new_value < 0 or new_value > 100:
+##             return false  # Reject out-of-range values
+##         return old_value != new_value
 ## [/codeblock]
 ##
 ## [param initial_value]: The starting value for the property
-## [param check_equality]: Whether to check equality before emitting (default: true)
-func _init(initial_value: Variant = null, check_equality := true) -> void:
+func _init(initial_value: Variant = null) -> void:
 	_value = initial_value
-	_check_equality = check_equality
 
 
 func _to_string() -> String:
@@ -147,7 +149,7 @@ func _get_value() -> Variant:
 
 
 func _set_value(new_value: Variant) -> void:
-	if _check_equality and _test_equality(_value, new_value):
+	if not _should_update(_value, new_value):
 		return
 
 	_value = new_value
@@ -156,15 +158,43 @@ func _set_value(new_value: Variant) -> void:
 		_on_next.emit(new_value)
 
 
+## Determines whether the value should be updated.
+##
+## Override this method to implement custom validation or change detection logic.
+## By default, this method returns true only when the new value differs from
+## the current value (equality check).
+##
+## Usage:
+## [codeblock]
+## # Always update (similar to old check_equality=false)
+## class AlwaysUpdateRP extends ReactiveProperty:
+##     func _should_update(old_value, new_value) -> bool:
+##         return true
+##
+## # Custom validation
+## class RangeRP extends ReactiveProperty:
+##     func _should_update(old_value, new_value) -> bool:
+##         if new_value < 0 or new_value > 100:
+##             return false
+##         return old_value != new_value
+## [/codeblock]
+##
+## [param old_value]: The current value
+## [param new_value]: The proposed new value
+## [br][b]Returns:[/b] True if the value should be updated, false otherwise
+func _should_update(old_value: Variant, new_value: Variant) -> bool:
+	return not _are_equal(old_value, new_value)
+
+
 ## Tests equality between two variants with proper null handling.
 ##
-## This static method provides safe equality comparison that properly
-## handles null values and type differences.
+## This private method provides safe equality comparison that properly
+## handles null values and type differences. Used internally by [method _should_update].
 ##
 ## [param a]: First value to compare
 ## [param b]: Second value to compare
 ## [br][b]Returns:[/b] True if the values are considered equal
-static func _test_equality(a: Variant, b: Variant) -> bool:
+static func _are_equal(a: Variant, b: Variant) -> bool:
 	if a == null and b == null:
 		return true
 

--- a/tests/reactive_property_test.gd
+++ b/tests/reactive_property_test.gd
@@ -1,5 +1,10 @@
 extends GdUnitTestSuite
 
+# Helper class for testing: Always updates even if values are equal
+class AlwaysUpdateRP extends ReactiveProperty:
+	func _should_update(_old_value: Variant, _new_value: Variant) -> bool:
+		return true # Always update, similar to old check_equality=false
+
 
 func test_standard1() -> void:
 	var result: Array[int] = []
@@ -41,19 +46,18 @@ func test_rp_equality() -> void:
 	var rp := ReactiveProperty.new(1)
 	rp.subscribe(result.append)
 	rp.value = 1
-	assert_array(result).contains_exactly([1])
 	rp.value = 2
-	assert_array(result).contains_exactly([1, 2])
+	rp.value = 2
+	assert_array(result).contains_exactly(1, 2)
 
 
 func test_rp_equality_disabled() -> void:
 	var result: Array[int] = []
-	var rp := ReactiveProperty.new(1, false)
+	var rp := AlwaysUpdateRP.new(1)
 	rp.subscribe(result.append)
 	rp.value = 1
-	assert_array(result).contains_exactly([1, 1])
 	rp.value = 2
-	assert_array(result).contains_exactly([1, 1, 2])
+	assert_array(result).contains_exactly(1, 1, 2)
 
 
 func test_rp_await() -> void:


### PR DESCRIPTION
## Summary
- Remove `check_equality` constructor parameter from ReactiveProperty
- Add overridable `_should_update(old_value, new_value)` method for custom validation logic
- Rename `static func _test_equality` to `func _are_equal` (private helper)
- Update tests to use new API with helper class `AlwaysUpdateRP`

## Breaking Changes
This is a breaking change for v1.0.0:
- Old API: `ReactiveProperty.new(value, false)` to disable equality checking
- New API: Override `_should_update()` in a subclass to customize update behavior

## Migration Example
```gdscript
# Before
var rp = ReactiveProperty.new(initial_value, false)

# After
class AlwaysUpdateRP extends ReactiveProperty:
    func _should_update(old, new) -> bool:
        return true

var rp = AlwaysUpdateRP.new(initial_value)
```

## Benefits
- Enhanced extensibility through method overriding
- Enables custom validation logic (e.g., range checks)
- Follows Godot's virtual method pattern (\_prefix)
- Cleaner API with fewer constructor parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)